### PR TITLE
Confirm executable permission on .vnc/xstartup

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -229,6 +229,7 @@ setup_vnc() {
 		# Launch Openbox Window Manager.
 		openbox-session &
 	_EOF_
+        chmod u+rx $HOME/.vnc/xstartup
 	if [[ $(pidof Xvnc) ]]; then
 		    echo -e ${ORANGE}"[*] Server Is Running..."
 		    { reset_color; vncserver -list; }


### PR DESCRIPTION
Following #28 which I had experienced the same problem with `termux 0.101`, `Xvnc TigerVNC 1.10.0 - built Dec  8 2020 19:04:02` where upon successful vnc connection with VNC Viewer a black screen would appear instead of a full openbox environment as depicted in README.md 

Enabling full verbose logging for vnc I saw that `sh` would complain about executing xstartup. Setting the executable permission to the file's user permissions (after it only had user read permission) fixed it.

`umask` on `bash` (which is the default shebang specified interpreter in setup script) on termux showed `0077` which I believe is why this was happening. Hence, confirming the 'x' bit after the writing > redirection to xstartup should resolve the issue on similar setups.