### PR TITLE
Added `pkg update -y` to setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -62,7 +62,7 @@ _pkgs=(bc bmon calc calcurse curl dbus desktop-file-utils elinks feh fontconfig-
 setup_base() {
 	echo -e ${RED}"\n[*] Installing Termux Desktop..."
 	echo -e ${CYAN}"\n[*] Updating Termux Base... \n"
-	{ reset_color; pkg autoclean; pkg upgrade -y; }
+	{ reset_color; pkg autoclean; pkg update -y; pkg upgrade -y; }
 	echo -e ${CYAN}"\n[*] Enabling Termux X11-repo... \n"
 	{ reset_color; pkg install -y x11-repo; }
 	echo -e ${CYAN}"\n[*] Installing required programs... \n"


### PR DESCRIPTION
Reference to Issue #43:

- user was failing to install `ncmpcpp` along with the `boost` package, part of termux-desktop's dependencies
- error points to `apt` failing to fetch dependencies from its sources
- looks like a typical outdated `apt`/`pkg` error (user has Termux for X months with no updates to `apt`/`pkg`)
- tested clean deployment in local env - OK
- tested clean deployment in Termux Docker env - OK
- source code is only referring `pkg upgrade -y`

Suggesting to add `pkg update -y` just before `pkg upgrade -y` and installing the needed dependencies 