### PR TITLE
Issue #99 - Moving PATH reference

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -99,7 +99,7 @@ setup_omz() {
 	{ reset_color; git clone https://github.com/robbyrussell/oh-my-zsh.git --depth 1 $HOME/.oh-my-zsh; }
 	cp $HOME/.oh-my-zsh/templates/zshrc.zsh-template $HOME/.zshrc
 	sed -i -e 's/ZSH_THEME=.*/ZSH_THEME="aditya"/g' $HOME/.zshrc
-	sed -i -e 's|# export PATH=.*|export PATH=$HOME/.local/bin:$PATH|g' $HOME/.zshrc
+
 	# ZSH theme
 	cat > $HOME/.oh-my-zsh/custom/themes/aditya.zsh-theme <<- _EOF_
 		# Default OMZ theme
@@ -266,6 +266,15 @@ setup_launcher() {
 	_EOF_
 	if [[ -f "$file" ]]; then
 		echo -e ${GREEN}"[*] Script ${ORANGE}$file ${GREEN}created successfully."
+	fi
+	
+	# defining PATH reference for ~/.local/bin in /etc/profile
+	# to avoid issues with launching the whole script, when zsh / oh-my-zsh fails to install
+	#   ref: https://github.com/adi1090x/termux-desktop/issues/99
+	echo "export PATH=${PATH}:${HOME}/.local/bin" >> ${PREFIX}/etc/profile
+	
+	if [[ $(grep "export PATH.*/home/.local/bin" ${PREFIX}/etc/profile | wc -l) > 0 ]]; then
+		echo -e ${GREEN}"[*] \$PATH reference ${ORANGE}~/.local/bin ${GREEN}added to /etc/profile successfully."
 	fi
 }
 


### PR DESCRIPTION
As raised in Issue #99, if a user is unable to successfully complete the `zsh` and `oh-my-zsh` setup, there is a chance the PATH reference to `~/.local/bin` is never added.

Besides not having a fancy shell, this means the user will also be unable to call the `startdesktop` script from anywhere in termux.

To avoid this issue, this PR proposes moving the PATH variable definition to **after the startup script being created**. This seems to be more logical since we're placing a file in said directory, in the same function.

Besides this change, also proposing changing the `rc` file where the variable is referenced, by using a system `rc` file (`/etc/profile`) instead of a shell-based `rc` file -- (there could be users preferring to use `bash` instead). As such, the PATH variable is being exported in `${PREFIX}/etc/profile` instead.
