### PR TITLE
Adding a Dockerfile for testing this repo locally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM  xeffyr/termux:latest
+
+WORKDIR /data/data/com.termux/files/home
+
+RUN apt update -y && apt install git 
+
+RUN git clone https://github.com/adi1090x/termux-desktop
+
+WORKDIR /data/data/com.termux/files/home/termux-desktop
+
+# COPY setup.sh setup.sh
+
+ENTRYPOINT [ "./setup.sh", "--install" ]


### PR DESCRIPTION
This is a placeholder Dockerfile to test how the installation script behaves.

It can be used as a base to perform changes and quickly test a deployment for errors. 

```
# setting up a termux container with the repo
docker build -t termux-desktop:latest .  

# running installation script
docker run --rm -ti --name termux-desktop termux-desktop:latest 
```

You can perform changes locally in your copy of the repo, and add the changed files within the Dockerfile, uncommenting the `COPY` statement and changing it if needed. Then, testing it is as easy as running it in a new, clean container.